### PR TITLE
FEP rollout: implement DR-002-Proc consequences (review copy)

### DIFF
--- a/docs/contribute/contribution_request/feature_request.rst
+++ b/docs/contribute/contribution_request/feature_request.rst
@@ -46,6 +46,17 @@ Roles
 
 **Architecture Community** - all architects and Feature Team leads with standing to review FEPs. During the Final Comment Period, every member is expected to either raise a substantive objection or approve, explicitly or by silence.
 
+Labels
+================================
+
+``fep`` is applied to the FEP PR and its tracking Issue throughout the whole lifecycle, and is what a board or filtered view is built on.
+
+``fep:needs-shepherd`` is applied to the tracking Issue while no Shepherd is confirmed, and removed once one is.
+
+``fep:fcp`` is applied to the tracking Issue only while it is in its Final Comment Period, and removed once the FCP closes.
+
+A FEP that sees no activity for an extended period, most commonly while unshepherded or shepherded but not yet ready for FCP, may be marked with the existing ``Stale`` label like any other inactive issue. This does not reject the FEP; it signals that it has lost momentum and may be picked up again later.
+
 The Process: Five Phases
 ================================
 
@@ -55,17 +66,17 @@ Post the idea informally in the S-CORE architecture channel before writing anyth
 
 **Phase 1 - Draft + Shepherd Shaping** (status: ``Draft``)
 
-Open a PR with your FEP draft, using the FEP template below. A FEP in draft, before a Shepherd is confirmed, does not need a GitHub Issue.
+Open a PR with your FEP draft, using the FEP template below. At the same time, open a tracking Issue of type *Epic*, labeled ``fep`` and ``fep:needs-shepherd``, and reference it in the FEP via the ``:tracking:`` field. The Issue links back to the FEP PR, giving bidirectional traceability.
 
-Once a Shepherd is confirmed, open a tracking Issue for the FEP, following the standard Change Request infrastructure described in the :ref:`Change Management Plan <change_mgmt_plan>`, and reference it in the FEP via the ``:tracking:`` field. The Issue links back to the FEP PR, giving bidirectional traceability.
+Once a Shepherd is confirmed, remove the ``fep:needs-shepherd`` label and update the tracking Issue to name the Shepherd.
 
-Author and Shepherd iterate until the proposal is complete and well-argued. When the Shepherd judges it ready, they signal readiness for the Final Comment Period. The Architecture Community chair (or proxy) then announces it to the full community.
+Author and Shepherd iterate until the proposal is complete and well-argued. When the Shepherd judges it ready, they propose entry into the Final Comment Period to the Architecture Community chair (or proxy). The chair/proxy then formally announces the FCP across all channels, including Slack, and adds the ``fep:fcp`` label to the tracking Issue.
 
 **Phase 2 - Final Comment Period (FCP)** (status: ``Under Review``)
 
-The Architecture Community has 10 calendar days to engage. Objections must be substantive and technical; the Shepherd distinguishes blocking from non-blocking feedback and can reset the FCP once if a significant new issue requires a revised proposal.
+The Architecture Community has 14 calendar days to engage. Objections must be substantive and technical; the Shepherd distinguishes blocking from non-blocking feedback and can reset the FCP once if a significant new issue requires a revised proposal.
 
-Silence is approval. FCP closes with no unresolved blocking objections, the FEP is accepted. FCP closes with unresolved blocking objections, the FEP is rejected. Escalation may intervene in exceptional cases but is not the default path.
+Silence is approval. FCP closes with no unresolved blocking objections, the FEP is accepted. FCP closes with unresolved blocking objections, the FEP is rejected. Escalation may intervene in exceptional cases but is not the default path. Either way, the ``fep:fcp`` label is removed from the tracking Issue once FCP closes.
 
 **Phase 3 - Decision** (status: ``Accepted`` | ``Rejected`` | ``Withdrawn``)
 
@@ -75,7 +86,7 @@ Breaking Change FEPs additionally require explicit approval from a minimum quoru
 
 **Phase 4 - Implementation Tracking** (status: ``Implementing`` -> ``Implemented``)
 
-The tracking Issue opened in Phase 1 stays open and becomes the implementation tracking artifact. It is closed only when the implementation, not the FEP, is merged. If implementation reveals the accepted design is materially wrong, file a follow-up FEP rather than diverging silently.
+The tracking Issue opened in Phase 1 stays open and becomes the implementation tracking artifact; being an Epic, it can carry child Task issues for the implementing teams. It is closed only when the implementation, not the FEP, is merged. If implementation reveals the accepted design is materially wrong, file a follow-up FEP rather than diverging silently.
 
 FEP Template
 ================================

--- a/docs/contribute/contribution_request/feature_request.rst
+++ b/docs/contribute/contribution_request/feature_request.rst
@@ -65,13 +65,13 @@ The Process: Five Phases
 
 Post the idea informally in the S-CORE architecture channel before writing anything formal. This surfaces obvious problems early, finds prior related proposals, and identifies whether a Shepherd might be willing to pick it up. Move to Phase 1 once you have a willing Shepherd.
 
-**Phase 1 - Draft + Shepherd Shaping** (status: ``Draft``)
+**Phase 1 - Draft + Shepherd Shaping** (status: ``Draft - Needs Shepherd`` -> ``Draft - Shepherded``)
 
-Open a PR with your FEP draft, using the FEP template below. At the same time, open a tracking Issue of type *Epic*, labeled ``fep`` and ``fep:needs-shepherd``, and reference it in the FEP via the ``:tracking:`` field. The Issue links back to the FEP PR, giving bidirectional traceability.
+Open a PR with your FEP draft, using the FEP template below. At the same time, open a tracking Issue of type *Feature Request*, labeled ``fep`` and ``fep:needs-shepherd``, set to status ``Draft - Needs Shepherd``, and reference it in the FEP via the ``:tracking:`` field. The Issue links back to the FEP PR, giving bidirectional traceability.
 
-Once a Shepherd is confirmed, remove the ``fep:needs-shepherd`` label and update the tracking Issue to name the Shepherd.
+Once a Shepherd is confirmed, remove the ``fep:needs-shepherd`` label, move the tracking Issue to status ``Draft - Shepherded``, and update it to name the Shepherd.
 
-Author and Shepherd iterate until the proposal is complete and well-argued. When the Shepherd judges it ready, they propose entry into the Final Comment Period to the Architecture Community chair (or proxy). The chair/proxy then formally announces the FCP across all channels, including Slack, and adds the ``fep:fcp`` label to the tracking Issue.
+Author and Shepherd iterate until the proposal is complete and well-argued. When the Shepherd judges it ready, they propose entry into the Final Comment Period to the Architecture Community chair (or proxy). The chair/proxy then formally announces the FCP across all channels, including Slack, moves the tracking Issue to status ``Under Review``, and adds the ``fep:fcp`` label.
 
 **Phase 2 - Final Comment Period (FCP)** (status: ``Under Review``)
 
@@ -81,13 +81,13 @@ Silence is approval. FCP closes with no unresolved blocking objections, the FEP 
 
 **Phase 3 - Decision** (status: ``Accepted`` | ``Rejected`` | ``Withdrawn``)
 
-If the FCP closed cleanly, the FEP PR is merged and recorded as a Decision Record. If the FCP closed with unresolved blocking objections, the FEP is rejected. The author may withdraw at any point before acceptance.
+If the FCP closed cleanly, the FEP PR is merged and recorded as a Decision Record. If the FCP closed with unresolved blocking objections, the FEP is rejected. The author may withdraw at any point before acceptance. In each case, the tracking Issue's status is updated to match: ``Accepted``, ``Rejected``, or ``Withdrawn``.
 
 Breaking Change FEPs additionally require explicit approval from a minimum quorum of Architecture Community members; they cannot pass by silence alone.
 
 **Phase 4 - Implementation Tracking** (status: ``Implementing`` -> ``Implemented``)
 
-The tracking Issue opened in Phase 1 stays open and becomes the implementation tracking artifact; being an Epic, it can carry child Task issues for the implementing teams. It is closed only when the implementation, not the FEP, is merged. If implementation reveals the accepted design is materially wrong, file a follow-up FEP rather than diverging silently.
+The tracking Issue opened in Phase 1 stays open, moves to status ``Implementing``, and becomes the implementation tracking artifact; it can carry child Task issues for the implementing teams via GitHub's sub-issue feature. It is closed only when the implementation, not the FEP, is merged, at which point it moves to status ``Implemented`` before closing. If implementation reveals the accepted design is materially wrong, file a follow-up FEP rather than diverging silently.
 
 FEP Template
 ================================

--- a/docs/contribute/contribution_request/feature_request.rst
+++ b/docs/contribute/contribution_request/feature_request.rst
@@ -1,136 +1,128 @@
-..
-   # *******************************************************************************
-   # Copyright (c) 2024 Contributors to the Eclipse Foundation
-   #
-   # See the NOTICE file(s) distributed with this work for additional
-   # information regarding copyright ownership.
-   #
-   # This program and the accompanying materials are made available under the
-   # terms of the Apache License Version 2.0 which is available at
-   # https://www.apache.org/licenses/LICENSE-2.0
-   #
-   # SPDX-License-Identifier: Apache-2.0
-   # *******************************************************************************
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 
 
-Feature Request Guideline
-##############################
+Feature & Enhancement Proposal (FEP) Process
+##############################################
 
 .. document:: Feature Request Guideline
   :id: doc__feature_request_guideline
   :status: valid
-  :version: 1
+  :version: 2
   :safety: QM
   :security: NO
   :realizes: wp__training_path[version==1]
 
-This Feature Request Guideline is a "How-To for Dummies" for proposing/contributing a new feature or changes to an existing feature.
-This Guideline is based on or references following documents:
-
-* :ref:`Contribution Guideline <contribute_contribution_guideline>`
-* :ref:`Change Management Plan <change_mgmt_plan>`
-* :need:`Feature Template <gd_temp__change_feature_request>`
-
-Creation of Feature Request
-================================
 .. _feature_request_guideline:
 
+This guide describes how to propose a **Feature & Enhancement Proposal (FEP)** in S-CORE. It applies to *Feature* change requests and to *Feature Modification* change requests with major impact, for example changes affecting the platform or other Feature Teams (see the routing note in the :ref:`Change Management Plan <change_mgmt_plan>` for how that classification is made).
 
-1. As the very first step, you will need to become an official contributor, as described in
-`Actions to Ensure Proper Contribution  <https://eclipse-score.github.io/score/main/contribute/general/contribution_attribution.html#contribution-attribution>`_
+It supersedes the previous ad hoc Feature Request review (GitHub label plus weekly Technical Lead review). Component-level and single-Feature-Team changes are not affected by this guide; they continue through the existing Change Request process described in the :ref:`Change Management Plan <change_mgmt_plan>`.
 
-2. Afterwards you will be able to create a GitHub Issue in the main `score repository <https://github.com/eclipse-score>`_
-and mark it
+This guide is based on or references the following documents:
 
-* with label *feature_request* if you want to propose a new feature, or
-* with label *feature_modification* if you want to propose changes to an existing feature,
+* :need:`FEP Decision Record (DR-002-Proc) <dec_rec__proc__fep_process>`, which records the original decision and its rationale
+* :ref:`Change Management Plan <change_mgmt_plan>`, which defines the underlying ISSUE/PR change request infrastructure used by every FEP
 
-as described in the :ref:`Change Management Plan <change_mgmt_plan>`.
+.. note::
+  This guide describes the FEP process as currently practiced and may evolve as the Architecture Community refines it. :need:`DR-002-Proc <dec_rec__proc__fep_process>` remains the frozen record of what was originally decided; it is not updated when this guide evolves.
 
-Please put a short description of your *feature request* into the GitHub Issue description, so that
-everyone can immediately understand, what the *feature request* is about.
+Roles
+================================
 
-The acceptance criteria for a feature request to be accepted are:
+**Author** - the person proposing the change. Responsible for writing and maintaining the FEP, integrating feedback, and driving consensus.
+
+**Shepherd** - an Architecture Community member, not the author, who guides the FEP to maturity and judges when it is ready for the Final Comment Period. Finding a Shepherd is the author's responsibility. If no one is willing to shepherd a proposal, it does not proceed.
+
+**Architecture Community** - all architects and Feature Team leads with standing to review FEPs. During the Final Comment Period, every member is expected to either raise a substantive objection or approve, explicitly or by silence.
+
+The Process: Five Phases
+================================
+
+**Phase 0 - Idea Exploration** (informal, no status)
+
+Post the idea informally in the S-CORE architecture channel before writing anything formal. This surfaces obvious problems early, finds prior related proposals, and identifies whether a Shepherd might be willing to pick it up. Move to Phase 1 once you have a willing Shepherd.
+
+**Phase 1 - Draft + Shepherd Shaping** (status: ``Draft``)
+
+Open a PR with your FEP draft, using the FEP template below. A FEP in draft, before a Shepherd is confirmed, does not need a GitHub Issue.
+
+Once a Shepherd is confirmed, open a tracking Issue for the FEP, following the standard Change Request infrastructure described in the :ref:`Change Management Plan <change_mgmt_plan>`, and reference it in the FEP via the ``:tracking:`` field. The Issue links back to the FEP PR, giving bidirectional traceability.
+
+Author and Shepherd iterate until the proposal is complete and well-argued. When the Shepherd judges it ready, they signal readiness for the Final Comment Period. The Architecture Community chair (or proxy) then announces it to the full community.
+
+**Phase 2 - Final Comment Period (FCP)** (status: ``Under Review``)
+
+The Architecture Community has 10 calendar days to engage. Objections must be substantive and technical; the Shepherd distinguishes blocking from non-blocking feedback and can reset the FCP once if a significant new issue requires a revised proposal.
+
+Silence is approval. FCP closes with no unresolved blocking objections, the FEP is accepted. FCP closes with unresolved blocking objections, the FEP is rejected. Escalation may intervene in exceptional cases but is not the default path.
+
+**Phase 3 - Decision** (status: ``Accepted`` | ``Rejected`` | ``Withdrawn``)
+
+If the FCP closed cleanly, the FEP PR is merged and recorded as a Decision Record. If the FCP closed with unresolved blocking objections, the FEP is rejected. The author may withdraw at any point before acceptance.
+
+Breaking Change FEPs additionally require explicit approval from a minimum quorum of Architecture Community members; they cannot pass by silence alone.
+
+**Phase 4 - Implementation Tracking** (status: ``Implementing`` -> ``Implemented``)
+
+The tracking Issue opened in Phase 1 stays open and becomes the implementation tracking artifact. It is closed only when the implementation, not the FEP, is merged. If implementation reveals the accepted design is materially wrong, file a follow-up FEP rather than diverging silently.
+
+FEP Template
+================================
 
 .. code-block:: markdown
 
-  - Feature Request is written according to the [Change Management](https://eclipse-score.github.io/score/main/process/process_areas/change_management/change_management_concept.html) & [Feature Request Template](https://eclipse-score.github.io/score/main/process/process_areas/change_management/guidance/change_management_feature_template.html)
-  - Feature requirements written according to the [Requirements Engineering](https://eclipse-score.github.io/score/main/process/process_areas/requirements_engineering/requirements_concept.html)
-  - If necessary: extend the stakeholder requirements written according to the [Requirements Engineering](https://eclipse-score.github.io/score/main/process/process_areas/requirements_engineering/requirements_concept.html)
+  # DR-NNN-<Category>: <Short imperative title>
 
+  - **Date:** YYYY-MM-DD
 
-Technical Leads review regularly all new incoming *feature requests* (GitHub Issues labeled as *feature_request* or *feature_modification*).
-This happens normally on Monday in the `Technical Lead circle <https://github.com/orgs/eclipse-score/discussions/104>`_.
-As soon as you've labeled your GitHub Issue with *feature request*/*feature_modification* label,
-TLs will see the *feature request* and will add it to the special GitHub project,
-`Feature Request GitHub Project <https://github.com/orgs/eclipse-score/projects/4>`_.
-Inside of this *Feature Request GitHub Project* additional states, as shown in the table below,
-are used for a better tracking of the *feature requests*.
-These states symbolize the status of the *feature request* and not the "GitHub" states of the issue, therefore we will further speak about
-*feature request status*. The initial status of every *feature request* is set to "Draft".
+  ```{dec_rec} <Short imperative title>
+  :id: dec_rec__<arch|proc|strat|infra|int>__<slug>
+  :status: draft
+  :tracking: <GitHub issue URL, required once a Shepherd is confirmed>
+  :context: <One sentence: what situation or gap makes this proposal necessary?>
+  :decision: <One sentence: what is being proposed?>
+  ```
 
-======================       ====================
-FR status                    Description
-======================       ====================
-**Draft**                    Feature Request is in the initial state
-**In Progress**              This is actively being worked on
-**In Review**                Feature Request should be reviewed by the technical leads
-**Accepted**                 Feature Request was accepted
-**Rejected**                 Feature request was rejected
-**Changes Requested**        Changes requested
-**POC Needed**               "Proof of concept" in incubation repository is needed
-======================       ====================
+  ---
 
-3. After you have created a GitHub Issue, next step would be to start working on the *feature request*.
-First of all, change the status of *Feature Request* to "in Progress" state.
-*Feature Requests*, that stay in the status "Draft" longer as 4 weeks, will be deleted.
-Afterwards create a PR with your proposal in the `/docs/features <https://github.com/eclipse-score/score/tree/main/docs/features>`_ score repository.
-There you will find currently existing features as subfolders. Please choose the one that fits your *feature request* the most or
-create a new subfolder, if none of existing feature match your *feature request*. Please take care, that the PR follows the :need:`Feature Template <gd_temp__change_feature_request>`.
-You should try to put as much information as possible, as a good exhaustive description is a prerequisite for *feature request* to be accepted.
+  ## Context / Problem
+  <!-- What problem does this solve? Why is the current state insufficient? -->
 
-It is important to understand, that *feature request* consists of an GitHub Issue, that is used to track organizational information and
-PR, that contains the technical content. This is explained once again in detailed in the :ref:`Change Management Worlflow <change_mgmt_workflow>`
-chapter of :ref:`Change Management Plan <change_mgmt_plan>` document. GitHub Issue always stays assigned to the owner of the *feature request*.
-*Feature Request* PR will always be assigned to the owner of the *feature request* as well, but will additionally get the list of reviewers, that
-should review this *feature request* PR.
+  ## Decision
+  <!-- What is being proposed, precisely? -->
 
+  ## Backwards Compatibility
+  <!-- Who is affected? What is the migration path? Remove if not a breaking change. -->
 
-Review of Feature Request
-================================
-* As soon as you're done with description of your *feature request*, please put the status into "Ready for Review" so that Technical Leads know,
-  that they can start with the process of reviewing the *feature request*. Technical Leads will first do a short review of your *feature request*:
+  ## Alternatives Considered
+  <!-- What other approaches did you evaluate and why were they rejected? -->
 
-  * In case the impact of your *feature request* is trivial, then TLs can process your *feature request* immediately.
-  * Normally, TL circle will put the lead of the appropriate *FT* or *Community* as reviewer to the corresponding PR of the *feature request* for better analysis.
-    The CTF/Community lead will change the status of the *feature request* issue to "in Review" as soon as they will start reviewing your *feature request*.
-    The review can be delegated to any other participants of the FT or Community.
+  ## Rationale
+  <!-- Why this approach over the alternatives? -->
 
-    * In case *feature request* can not be clearly assigned to any already existing team, Technical Lead circle will pick at least two suitable candidates
-      from the project to review the *feature request* PR. In that case, *feature request* should be reviewed by all reviewers.
+  ## Consequences
+  <!-- What changes after acceptance? What must be implemented, updated, or tracked? -->
 
-  * In case of big architectural impact, Technical Lead circle can additionally decide to request a review for *feature request* PR from software architecture community.
+  ## Rejected Ideas
+  <!-- Ideas raised during FCP that were explicitly not adopted, with rationale. Remove if empty. -->
 
-* After the review is done, the TL circle will set the status of the *feature request* accordingly and will
-  also put all further necessary information as GitHub Issue comments. The outcome of the review could be like following:
+Breaking Change FEPs - Additional Requirements
+================================================
 
-  * **Accepted** - You *feature request* is accepted. The *feature request* GitHub Issue should contain now a link to a new GitHub issue of type 'Epic',
-    that was created by Technical Leads, where detailed information regarding your feature is documented.
-    The epic should be also already assigned to the corresponding team (FT/Community).
-    If none of the FTs/Communities match the new *feature request*, then a new FT/Community will be founded.
-    You will be invited to the FT/Community for break down of the *feature request* and planning.
-    You can now merge the *feature request* PR and close the *feature request* issue.
-  * **Rejected** - You *feature request* was rejected. It could be either because your description was
-    not mature enough or because the proposal technically doesn't fit into S-CORE roadmap or architecture.
-    You will be able to find the summary of the review in the corresponding *feature request* issue comments.
-    The review comments will be done directly in the *feature request* PR.
-  * **Changes Requested** - We like your idea, but we would like to request some modifications.
-    This could be rather technical topics or also syntax issues in the description.
-    You will be able to find the summary of the review in the corresponding *feature request* issue comments.
-    The review comments will be done directly in the *feature request* PR.
-  * **POC needed** - We generally like your idea, but we don't have enough technical understanding of the *feature request*,
-    e.g. technical scope is too big, and we need a POC to be able to understand better,
-    how the proposed *feature request* fits into the overall solution. You will find in the GitHub issue comments
-    the decsription for both the scope of the PoC and the requirements and the acceptance criteria for the requested PoC.
-    Also, a so called *incubation repository* will be created by the reviewers of the *feature request*, where you should implement your POC.
-    Please be aware, that POC is not a guarantee, that you *feature request* will be accepted.
+A proposal classified as **Breaking Change** must additionally include:
+
+* **Impact Inventory**: explicit list of known integrators, configurations, or customer deliverables that will break
+* **Migration Path**: concrete steps integrators must take, with estimated effort
+* **Deprecation Timeline**: if a grace period is offered, how long and how the old behavior is signaled as deprecated
+* **Sign-off from Affected Teams**: acknowledgment, not necessarily approval, from leads of teams known to be directly affected before FCP entry

--- a/docs/contribute/contribution_request/feature_request.rst
+++ b/docs/contribute/contribution_request/feature_request.rst
@@ -1,15 +1,16 @@
-# *******************************************************************************
-# Copyright (c) 2024 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# SPDX-License-Identifier: Apache-2.0
-# *******************************************************************************
+..
+   # *******************************************************************************
+   # Copyright (c) 2024 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
 
 
 Feature & Enhancement Proposal (FEP) Process

--- a/docs/platform_management_plan/change_management.rst
+++ b/docs/platform_management_plan/change_management.rst
@@ -1,15 +1,16 @@
-# *******************************************************************************
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# SPDX-License-Identifier: Apache-2.0
-# *******************************************************************************
+..
+   # *******************************************************************************
+   # Copyright (c) 2025 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
 
 .. document:: Change Management Plan
    :id: doc__platform_change_management_plan

--- a/docs/platform_management_plan/change_management.rst
+++ b/docs/platform_management_plan/change_management.rst
@@ -132,7 +132,7 @@ Changes are clustered in the following types:
 Routing to the FEP Process
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**Feature** change requests go through the FEP process (:need:`DR-002-Proc <dec_rec__proc__fep_process>`).
+**Feature** change requests go through the FEP process (see the :ref:`FEP Process Guide <feature_request_guideline>`).
 
 **Feature Modification** change requests go through the FEP process when the change has major impact, e.g. affecting the platform or other Feature Teams. Feature Teams retain authority over modifications limited to their own domain.
 

--- a/docs/platform_management_plan/change_management.rst
+++ b/docs/platform_management_plan/change_management.rst
@@ -1,16 +1,15 @@
-..
-   # *******************************************************************************
-   # Copyright (c) 2025 Contributors to the Eclipse Foundation
-   #
-   # See the NOTICE file(s) distributed with this work for additional
-   # information regarding copyright ownership.
-   #
-   # This program and the accompanying materials are made available under the
-   # terms of the Apache License Version 2.0 which is available at
-   # https://www.apache.org/licenses/LICENSE-2.0
-   #
-   # SPDX-License-Identifier: Apache-2.0
-   # *******************************************************************************
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 
 .. document:: Change Management Plan
    :id: doc__platform_change_management_plan
@@ -130,6 +129,16 @@ Changes are clustered in the following types:
      - Created by :need:`Contributor <rl__contributor>` to change requirements and work products, scope change
      - ISSUE with label ``component_modification``
 
+Routing to the FEP Process
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Feature** change requests go through the FEP process (:need:`DR-002-Proc <dec_rec__proc__fep_process>`).
+
+**Feature Modification** change requests go through the FEP process when the change has major impact, e.g. affecting the platform or other Feature Teams. Feature Teams retain authority over modifications limited to their own domain.
+
+A clean, exhaustive definition of "major impact" is not achievable up front. This classification is a judgment call made by the responsible :need:`Committer <rl__committer>` at the time the change is proposed, including changes proposed directly as a PR without a prior FEP. A change can be waived from the FEP process by community agreement if it is judged not to warrant it, or pulled into the FEP process after the fact if a maintainer judges it major.
+
+**Component** and **Component Modification** change requests are unaffected by the FEP process.
 
 Change Request Traceability Impact Analysis requires the following tools:
 

--- a/docs/platform_management_plan/project_management.rst
+++ b/docs/platform_management_plan/project_management.rst
@@ -1,16 +1,15 @@
-..
-   # *******************************************************************************
-   # Copyright (c) 2024 Contributors to the Eclipse Foundation
-   #
-   # See the NOTICE file(s) distributed with this work for additional
-   # information regarding copyright ownership.
-   #
-   # This program and the accompanying materials are made available under the
-   # terms of the Apache License Version 2.0 which is available at
-   # https://www.apache.org/licenses/LICENSE-2.0
-   #
-   # SPDX-License-Identifier: Apache-2.0
-   # *******************************************************************************
+# *******************************************************************************
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 
 .. document:: Project Management Plan
    :id: doc__project_mgt_plan
@@ -104,7 +103,7 @@ Steering of the project is done with the help of *Lead Circles*.
      - **-----------**
      - **-----------------------**
    * - - Decisions about strategical topics
-       - Review and approval of contributions, e.g. Feature Requests, which add or modify features
+       - Triage of incoming Feature Requests, routing platform-level and cross-Feature-Team requests to the FEP process
        - Project Management
        - High-level project control and coordination between multiple software modules.
        - Deciding of adding / removing Repositories
@@ -514,7 +513,6 @@ Each *Feature Team* has one *Lead* to organize the Team`s work.
      - `ORCSLC`_
      - `ORCBKL`_
      - | https://github.com/eclipse-score/orchestrator
-
    * - .. _pmp_pm_per:
 
        **PER**
@@ -677,7 +675,8 @@ Architectural Issues
 A *Feature Request* represents an independent work package used to describe and
 track a high-level request for the project. *Feature Request* work packages can be linked to
 other work packages, but they must not be treated as parent work packages. *Feature Request* covers new Features as well as significant modifications of existing Features.
-They are in the responsibility of the :ref:`Architecture Community <pmp_pm_arc>`, shall aligned with :ref:`Project / Technical Lead Circle <pmp_pm_plctlc>` and the issues are part of the :ref:`Root Repository <pmp_pm_root_repository>`.
+
+Feature Requests are governed by the FEP process (:need:`DR-002-Proc <dec_rec__proc__fep_process>`): the :ref:`Architecture Community <pmp_pm_arc>` owns the review via a Shepherd and Final Comment Period. The :ref:`Project / Technical Lead Circle <pmp_pm_plctlc>` triages incoming requests and is notified once a FEP enters its Final Comment Period, for roadmap awareness. Feature Requests are part of the :ref:`Root Repository <pmp_pm_root_repository>`.
 
 `About Features <https://eclipse-score.github.io/score/main/features/index.html>`_
 

--- a/docs/platform_management_plan/project_management.rst
+++ b/docs/platform_management_plan/project_management.rst
@@ -1,15 +1,16 @@
-# *******************************************************************************
-# Copyright (c) 2024 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# SPDX-License-Identifier: Apache-2.0
-# *******************************************************************************
+..
+   # *******************************************************************************
+   # Copyright (c) 2024 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
 
 .. document:: Project Management Plan
    :id: doc__project_mgt_plan

--- a/docs/platform_management_plan/project_management.rst
+++ b/docs/platform_management_plan/project_management.rst
@@ -676,7 +676,7 @@ A *Feature Request* represents an independent work package used to describe and
 track a high-level request for the project. *Feature Request* work packages can be linked to
 other work packages, but they must not be treated as parent work packages. *Feature Request* covers new Features as well as significant modifications of existing Features.
 
-Feature Requests are governed by the FEP process (:need:`DR-002-Proc <dec_rec__proc__fep_process>`): the :ref:`Architecture Community <pmp_pm_arc>` owns the review via a Shepherd and Final Comment Period. The :ref:`Project / Technical Lead Circle <pmp_pm_plctlc>` triages incoming requests and is notified once a FEP enters its Final Comment Period, for roadmap awareness. Feature Requests are part of the :ref:`Root Repository <pmp_pm_root_repository>`.
+Feature Requests are governed by the FEP process (see the :ref:`FEP Process Guide <feature_request_guideline>`): the :ref:`Architecture Community <pmp_pm_arc>` owns the review via a Shepherd and Final Comment Period. The :ref:`Project / Technical Lead Circle <pmp_pm_plctlc>` triages incoming requests and is notified once a FEP enters its Final Comment Period, for roadmap awareness. Feature Requests are part of the :ref:`Root Repository <pmp_pm_root_repository>`.
 
 `About Features <https://eclipse-score.github.io/score/main/features/index.html>`_
 

--- a/docs/platform_management_plan/project_management.rst
+++ b/docs/platform_management_plan/project_management.rst
@@ -675,7 +675,7 @@ Architectural Issues
 
 A *Feature Request* represents an independent work package used to describe and
 track a high-level request for the project. *Feature Request* work packages can be linked to
-other work packages, but they must not be treated as parent work packages. *Feature Request* covers new Features as well as significant modifications of existing Features.
+other work packages, including as a parent to child Task issues used for implementation tracking once a FEP is accepted. *Feature Request* covers new Features as well as significant modifications of existing Features.
 
 Feature Requests are governed by the FEP process (see the :ref:`FEP Process Guide <feature_request_guideline>`): the :ref:`Architecture Community <pmp_pm_arc>` owns the review via a Shepherd and Final Comment Period. The :ref:`Project / Technical Lead Circle <pmp_pm_plctlc>` triages incoming requests and is notified once a FEP enters its Final Comment Period, for roadmap awareness. Feature Requests are part of the :ref:`Root Repository <pmp_pm_root_repository>`.
 

--- a/docs/users_guide/project_basics/software_architecture_overview.rst
+++ b/docs/users_guide/project_basics/software_architecture_overview.rst
@@ -26,7 +26,7 @@ Please note that the Eclipse S-CORE´s software architecture is continuously ref
 Eclipse S-CORE has a `software architecture community <https://github.com/orgs/eclipse-score/discussions/categories/architecture-community>`_
 **responsible for maintaining and evolving the architecture**.
 
-Structural changes and new functionality are proposed through the **FEP process** (:need:`DR-002-Proc <dec_rec__proc__fep_process>`).
+Structural changes and new functionality are proposed through the **FEP process**.
 All **past feature requests** are documented in the corresponding
 `Feature Requests / Modification <https://github.com/orgs/eclipse-score/projects/4/views/1>`_ GitHub project.
 

--- a/docs/users_guide/project_basics/software_architecture_overview.rst
+++ b/docs/users_guide/project_basics/software_architecture_overview.rst
@@ -1,16 +1,15 @@
-..
-   # *******************************************************************************
-   # Copyright (c) 2026 Contributors to the Eclipse Foundation
-   #
-   # See the NOTICE file(s) distributed with this work for additional
-   # information regarding copyright ownership.
-   #
-   # This program and the accompanying materials are made available under the
-   # terms of the Apache License Version 2.0 which is available at
-   # https://www.apache.org/licenses/LICENSE-2.0
-   #
-   # SPDX-License-Identifier: Apache-2.0
-   # *******************************************************************************
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
 
 Software Architecture Overview
 ================================
@@ -27,11 +26,11 @@ Please note that the Eclipse S-CORE´s software architecture is continuously ref
 Eclipse S-CORE has a `software architecture community <https://github.com/orgs/eclipse-score/discussions/categories/architecture-community>`_
 **responsible for maintaining and evolving the architecture**.
 
-By creating a **feature request**, structural changes as well as new functionality can be **proposed at any time**.
+Structural changes and new functionality are proposed through the **FEP process** (:need:`DR-002-Proc <dec_rec__proc__fep_process>`).
 All **past feature requests** are documented in the corresponding
 `Feature Requests / Modification <https://github.com/orgs/eclipse-score/projects/4/views/1>`_ GitHub project.
 
-The **process for submitting a feature request** is described in the :ref:`contribution guide <feature_request_guideline>`.
+The **process for submitting a FEP** is described in the :ref:`FEP Process Guide <feature_request_guideline>`.
 Participation in the architecture process is encouraged.
 
 The **software architecture community regularly organizes workshops** where contributors can:

--- a/docs/users_guide/project_basics/software_architecture_overview.rst
+++ b/docs/users_guide/project_basics/software_architecture_overview.rst
@@ -1,15 +1,16 @@
-# *******************************************************************************
-# Copyright (c) 2026 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# SPDX-License-Identifier: Apache-2.0
-# *******************************************************************************
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
 
 Software Architecture Overview
 ================================


### PR DESCRIPTION
Four changes, one commit each:

1. Feature Request Guideline rewritten as the living FEP Process Guide. Supersedes the old GitHub-label + weekly TL review; DR-002-Proc stays the frozen decision record, the Change Management Plan stays the owner of the generic ISSUE/PR mechanics.
2. Project Management Plan: corrected the PLC/TLC steering table and the Feature Request definition, both of which still described TL Circle review/approval, to reflect Architecture Community ownership via the FEP process and TL Circle triage.
3. Change Management Plan: added a routing note. Feature CRs always go through FEP. Feature Modification CRs go through FEP only for major impact (platform or cross-FT), a judgment call by the responsible Committer rather than a fixed rule. Component/Component Modification unaffected.
4. Software Architecture Overview: swapped the Feature Request Guideline reference for the FEP process reference.

Process Description - Change Management needs no textual change (verification only, per DR-002-Proc).